### PR TITLE
Restrict monospaced fonts to serif ones, i.e. Courier family.

### DIFF
--- a/mathdown.css
+++ b/mathdown.css
@@ -32,14 +32,14 @@ body { height: 80%; width: 95%; }
 
 .CodeMirror {
   /* Font choices based on Math.SE: http://graphicdesign.stackexchange.com/a/12961 */
-  font-family: Georgia, "Bitstream Charter", "Times New Roman", Times, serif;
+  font-family: "Georgia", "Bitstream Charter", "Times New Roman", "Times", serif;
 }
 /* markdown mode styles `...` and indented code blocks as "comment". */
 .cm-comment, .cm-leadingspace, .cm-formatting-list {
   /* Prefer Courier and similar serif monospaced fonts.
-     Put Nimbus Mono L first to avoid Courier New -> Liberation Mono
-     substitution on linux (it's metrically compatible but sans-serif). */
-  font-family: Nimbus Mono L, Courier New, Courier, monospace;
+     Prefer Nimbus Mono L to Courier New -> Liberation Mono substitution
+     on linux (it's metrically compatible but sans-serif). */
+  font-family: "Courier 10 Pitch", "Nimbus Mono L", "Courier New", "Courier", monospace;
 }
 
 /* Match h1..h6 default sizes in WebKit, Mozilla & IE as of 2013. */

--- a/mathdown.css
+++ b/mathdown.css
@@ -34,6 +34,14 @@ body { height: 80%; width: 95%; }
   /* Font choices based on Math.SE: http://graphicdesign.stackexchange.com/a/12961 */
   font-family: Georgia, "Bitstream Charter", "Times New Roman", Times, serif;
 }
+/* markdown mode styles `...` and indented code blocks as "comment". */
+.cm-comment, .cm-leadingspace, .cm-formatting-list {
+  /* Prefer Courier and similar serif monospaced fonts.
+     Put Nimbus Mono L first to avoid Courier New -> Liberation Mono
+     substitution on linux (it's metrically compatible but sans-serif). */
+  font-family: Nimbus Mono L, Courier New, Courier, monospace;
+}
+
 /* Match h1..h6 default sizes in WebKit, Mozilla & IE as of 2013. */
 pre.cm-header-1 { font-size: 2.00em; }
 pre.cm-header-2 { font-size: 1.50em; }
@@ -58,8 +66,6 @@ pre.cm-header { padding-top: 0.5em; padding-bottom: 0.5em; }
 .cm-s-default .cm-keyword { color: #470052; }
 .cm-s-default .cm-keyword.cm-formatting-list { color: #708; }
 */
-/* markdown mode styles `...` and indented code blocks as "comment". */
-.cm-comment, .cm-leadingspace, .cm-formatting-list { font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace; }
 /* exclude math from monospace style to avoid mathjax vertically
    squishing formulas, especially display. */
 .cm-comment.inline_math, .cm-comment.display_math { font-family: serif; }


### PR DESCRIPTION
I'm not sure it's a win for readability but I'm assuming a serif monospaced font would look better among serif text (and math).
Almost all monospaced fonts are sans-serif; [Courier and derivatives](https://en.wikipedia.org/wiki/Courier_%28typeface%29) are AFAICT the only serif monospaced fonts that come pre-installed.  (For now I'm not considering web fonts e.g. TeX Gyre Cursor — unicode coverage tends to be low and I don't want the extra loading).

Before: http://www.browserstack.com/screenshots/da632239cca396927592b1aa5de3df569d2646ae
After: http://www.browserstack.com/screenshots/e3459310270061ddca648b82ec50acc0415177fe
- On Windows old and new look OK but new is a better match to surrounding serif.
- On OS X, old was too heavy and high x-height, new is too light with OK x-height.
- On Linux, old was [sometimes not even monospaced?!](http://browsershots.org/screenshots/b521259db3b858d7092dbc89ed263e88)
  but usually [sans, a bit light and too high — probably Liberation Mono replacing Courier](http://browsershots.org/screenshots/820d0ce92f5a322888efefe09b9cc223).
  New is [a bit too light](http://browsershots.org/screenshots/4dae1abf4fb2f8db336faba735501042) and sometimes [too low x-height](http://browsershots.org/screenshots/0fe7f94e8fd8930757580dc070912710).

TODO: Test [Courier 10 Pitch](http://typographyforlawyers.com/courier-10-pitch.html) which should look better (and not so light) on Linux.
