### PR TITLE
Fix #138 - MS Edge version in test didn't on Sauce Labs

### DIFF
--- a/test/browser-on-saucelabs.spec.coffee
+++ b/test/browser-on-saucelabs.spec.coffee
@@ -47,7 +47,7 @@ desiredBrowsers = [
   # Desktop:
   {browserName: 'internet explorer', version: '8.0', platform: 'Windows XP'}
   {browserName: 'internet explorer', version: '11.0', platform: 'Windows 10'}
-  {browserName: 'microsoftedge', version: '20.10240'}
+  {browserName: 'MicrosoftEdge'}
   # arbitrary somewhat old - but not ancient - FF and Chrome versions.
   {browserName: 'firefox', version: '30.0', platform: 'Linux'}
   {browserName: 'chrome', version: '30.0', platform: 'Linux'}


### PR DESCRIPTION
They currently have only 13.10586 but I expect it to change repeatedly.
[https://wiki.saucelabs.com/display/DOCS/Platform+Configurator]
Instead I'm just dropping the version.
(https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-RequiredSeleniumTestConfigurationSettings
says version is requires and describes 'latest' value for
Chrome & FF.  But that fails for Edge, while omitting works.)
