### PR TITLE
[test] Bump a the newer of Safari and IE pairs to 'latest'

### DIFF
--- a/test/browser-on-saucelabs.spec.coffee
+++ b/test/browser-on-saucelabs.spec.coffee
@@ -46,13 +46,13 @@ desiredBrowsers = [
   # Generated with https://docs.saucelabs.com/reference/platforms-configurator/
   # Desktop:
   {browserName: 'internet explorer', version: '8.0', platform: 'Windows 7'}
-  {browserName: 'internet explorer', version: '11.0', platform: 'Windows 10'}
+  {browserName: 'internet explorer', version: 'latest', platform: 'Windows 10'}
   {browserName: 'MicrosoftEdge'}
   # arbitrary somewhat old - but not ancient - FF and Chrome versions.
   {browserName: 'firefox', version: '30.0', platform: 'Linux'}
   {browserName: 'chrome', version: '35.0', platform: 'Linux'}
-  {browserName: 'Safari', version: '10.0', platform: 'macOS 10.12'}
   {browserName: 'Safari', version: '7.0', platform: 'OS X 10.9'}
+  {browserName: 'Safari', version: 'latest', platform: 'macOS 10.12'}
   # Mobile (doesn't mean it's usable though):
   {browserName: 'Safari', deviceName: 'iPad Simulator', platformName: 'iOS', platformVersion: '8.4'}
 #  {browserName: 'Browser', deviceName: 'Android Emulator', platformName: 'Android', platformVersion: '4.4'}


### PR DESCRIPTION
Safari 10.0 on latest macOS fell off Sauce Labs support matrix, needed bump to 10.1.
As always I wish to use 'oldest' per each OS, but that's not supported, need to bump frequently to ride the back wave :-(
At least for the browsers I'm running 2 of, it sounds OK for the one on newer OS to use latest rather than oldest.  Hope this may reduce CI breakage frequency a bit...