### PR TITLE
Switch production from NodeJS 8 to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,9 @@ language: node_js
 # Should test the Node version that runs in production.
 # https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions
 # https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version
-# I believe RHcloud (openshift 2) was running 0.11 but it's being sunset anyway.
 node_js:
-  - 6
-  - 8
+  - 10
+  - 11
 
 # http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/
 cache:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "wd": "~1.10.3"
   },
   "engines": {
-    "node": "8.x"
+    "node": "10.x"
   },
   "main": "server.coffee",
   "scripts": {


### PR DESCRIPTION
Stop testing old versions, now test 10 & 11.

- [x] I'm also now upgrading (in Heroku UI, not controlled by code) from `cedar-14` to `heroku-18` stack: https://devcenter.heroku.com/articles/heroku-18-stack EDIT: DONE