### PR TITLE
$\alpha$ test: Allow U+1D6FC MATHEMATICAL ITALIC SMALL ALPHA

### DIFF
--- a/test/browser-on-saucelabs.spec.coffee
+++ b/test/browser-on-saucelabs.spec.coffee
@@ -139,7 +139,7 @@ describeBrowserTest = (browserName, getDesired, getSite) ->
             expect(err).to.be(null)
             el.text (err, text) ->
               expect(err).to.be(null)
-              expect(text).to.match(/^\s*α\s*$/)
+              expect(text).to.match(/^\s*(α|𝛼)\s*$/)
               eachPassed = true
               done()
 


### PR DESCRIPTION
in addition to U+03B1 GREEK SMALL LETTER ALPHA.
Math alpha seen with MathJax 2.7.5 which mathdown is now yet using
(currently 2.4.0 + 2 commits), but won't hurt.