### PR TITLE
Drop sync-exec package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -918,12 +918,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "sync-exec": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
-      "integrity": "sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=",
-      "dev": true
-    },
     "tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "expect.js": "~0.3.1",
     "mocha": "~5.2.0",
     "sauce-tunnel": "~2.5.0",
-    "sync-exec": "~0.6.2",
     "wd": "git+https://github.com/admc/wd.git#master"
   },
   "engines": {

--- a/test/lib/test-metadata.coffee
+++ b/test/lib/test-metadata.coffee
@@ -1,4 +1,4 @@
-execSync = require('sync-exec')
+execSync = require('child_process').execSync
 
 # Continuous integration metadata
 # ===============================
@@ -33,7 +33,7 @@ exports.getBuildInfo = ->
     else
       # Synthesize unique build string for local `npm test` runs.
       console.log('Running `git describe` to get build info...')
-      versionInfo = execSync('git describe --always --all --long --dirty').stdout.trim()
+      versionInfo = execSync('git describe --always --all --long --dirty').toString().trim()
       timestamp = new Date().toISOString()
       "Local at #{versionInfo} on #{timestamp}"
   buildInfo


### PR DESCRIPTION
Now available builtin in Node.
Honestly, this is to stop Github & Snyk pestering me that sync-exec has a vulnerability (which is not a problem in my test, I use a fixed command string) :wink: