### PR TITLE
New wd fixes #187 safari failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
     },
     "async": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/async/-/async-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
       "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
       "dev": true,
       "requires": {
@@ -504,9 +504,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "inflight": {
@@ -1006,9 +1006,8 @@
       }
     },
     "wd": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-1.11.1.tgz",
-      "integrity": "sha512-XNK6EbOrXF7cG8f3pbps6mb/+xPGZH2r1AL1zGJluGynA/Xt6ip1Tvqj2AkavyDFworreaGXoe+0AP/r7EX9pg==",
+      "version": "git+https://github.com/admc/wd.git#c7d022f10a3585512f7d0892c8e33925df68d4c6",
+      "from": "git+https://github.com/admc/wd.git#master",
       "dev": true,
       "requires": {
         "archiver": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "mocha": "~5.2.0",
     "sauce-tunnel": "~2.5.0",
     "sync-exec": "~0.6.2",
-    "wd": "~1.11.1"
+    "wd": "git+https://github.com/admc/wd.git#master"
   },
   "engines": {
     "node": "8.x"


### PR DESCRIPTION
master includes https://github.com/admc/wd/pull/574,
not included yet in npm tagged versions.