### PR TITLE
David font: constrain to Hebrew letters, force right-slanted faux oblique

### DIFF
--- a/mathdown.css
+++ b/mathdown.css
@@ -65,11 +65,35 @@ body { height: 80%; width: 95%; }
   body { display: table; }
   form { display: table-row; } */
 
+/* David is the best-matching serif Hebrew style.
+   But its italic is problematic: slants to the left, which inherently
+   does't mix well with right-slanted latin; the Culmus version also
+   "takes over" punctuation to be left-slanted, and even English letters
+   to remain upright :-(
+   KLUDGE: hide the native italic from the browser, to force "faux oblique"
+   that will slant to the right!  https://stackoverflow.com/a/25583439/239657
+   Also, constrain to Hebrew block to avoid taking over other scripts.
+*/
+@font-face {
+  font-family: 'DavidWithoutItalic';
+  font-style: normal;
+  font-weight: normal;
+  unicode-range: U+0590-05FF, U+FB1D-FB4F; /* Hebrew, Hebrew subset of Alphabetic Presentation Forms */
+  src: local('David CLM Medium'), local('David'), local('David Regular');
+}
+@font-face {
+  font-family: 'DavidWithoutItalic';
+  font-style: normal;
+  font-weight: bold;
+  unicode-range: U+0590-05FF, U+FB1D-FB4F; /* Hebrew, Hebrew subset of Alphabetic Presentation Forms */
+  src: local('David CLM Bold'), local('David Bold');
+}
+
 /* Font choices based on Math.SE: http://graphicdesign.stackexchange.com/a/12961 */
 /* "lining_numerals_charter" replaces only the digits 0-9, comes from fonts/ subdir.
    See https://github.com/cben/mathdown/issues/95 */
 .CodeMirror {
-  font-family: "lining_numerals_charter", "Georgia", "Bitstream Charter", "David", "David CLM", "Times New Roman", "Times", serif;
+  font-family: "lining_numerals_charter", "Georgia", "Bitstream Charter", "DavidWithoutItalic", "Times New Roman", "Times", serif;
 }
 /* markdown mode styles `...` and indented code blocks as "comment". */
 .cm-comment, .cm-leadingspace, .cm-formatting-list, .cm-formatting-quote, .cm-formatting-task {


### PR DESCRIPTION
Fixes #198, see details there.
(1) Prevents David from taking over non-Hebrew letters (2) forces italic to use faux right-slanted Hebrew letters.

(Followup to b83684ead9d72ead641a220e80a782aa783933b6 (#65) which introduced these fonts without testing on systems where they're front of the stack.  Tested on Linux, not windows.)

Before:
![www mathdown net__doc=CTrq2WEaURk(iPhone 5_SE) (6)](https://user-images.githubusercontent.com/273688/76713052-bc12fa80-6726-11ea-9b00-fd5b609532ab.png)
After:
![_home_cben_md_mathdown_index html_doc=CTrq2WEaURk](https://user-images.githubusercontent.com/273688/76732968-8858c480-6768-11ea-9a43-bcbceaba989e.png)
