### PR TITLE
Referer policy: Don't send ?doc=SECRET in external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="X-UA-Compatible" content="IE=Edge"/>
     <meta charset="utf-8"/>
+    <meta name="referrer" content="strict-origin">
 
     <!--
         This page is used to render all mathdown documents, using URLs such as


### PR DESCRIPTION
[extracted from `view` branch, this looks like a safe win]

Affects all requests made from the page.  Notable external links:

- "bugs" link to https://github.com/cben/mathdown/issues

  Instead of sending e.g.: Referer: http://localhost:8000/mathdown/?doc=SECRET this will send Referer: http://localhost:8000/

  Until now, users have been revealing secret ?doc=... not only to Heroku but also to Github, which is unnecessary. What's worse, GitHub has Insights -> Traffic tab, showing referer info!  Luckily, it includes path but not ?query params.  Phew!

- [possible future — `view` branch] When making ajax request for viewed markdown file

  Instead of sending e.g.:  
  `Referer: http://localhost:8000/mathdown/?viewurl=https://raw.githubusercontent.com/commonmark/commonmark-spec/0.29/README.md`  
  this will send  
  `Referer: http://localhost:8000/`

Tested on Firefox (back in 2020).

doc: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#integration_with_html